### PR TITLE
Correction objet et message persistés après envoi message

### DIFF
--- a/jeu/messagerie.php
+++ b/jeu/messagerie.php
@@ -6,6 +6,12 @@ $mysqli = db_connexion();
 
 include ('../nb_online.php');
 
+if(isset($_GET["envoi"]) && $_GET["envoi"] == 'ok'){
+	unset($_SESSION['destinataires']);
+	unset($_SESSION['objet']);
+	unset($_SESSION['message']);
+}
+
 if(isset($_SESSION["id_perso"])){
 ?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">


### PR DESCRIPTION
Fil de discussion : http://nordvssud-creation.forumactif.com/t290-messagerienouveau-message-reprend-les-messages-envoye-a-tous-par-le-chef

Pour reproduire le problème : 
1°) Envoyer un message à plusieurs destinataires (quand on envoi à un seul destinataire, le problème n'apparait pas)
2°) Cliquer sur nouveau message
3°) Les champs "objet" et "message" affichent les objet et message précédemment envoyés